### PR TITLE
Suppress sun.misc.Unsafe deprecation warning on Java 23+

### DIFF
--- a/src/functionalTest/java/name/remal/gradle_plugins/lombok/LombokPluginFunctionalTest.java
+++ b/src/functionalTest/java/name/remal/gradle_plugins/lombok/LombokPluginFunctionalTest.java
@@ -27,6 +27,9 @@ class LombokPluginFunctionalTest {
 
     @BeforeEach
     void beforeEach() {
+        project.addForbiddenMessage("A terminally deprecated method in sun.misc.Unsafe has been called");
+        project.addForbiddenMessage("sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit");
+
         project.forBuildFile(build -> {
             build.applyPlugin("name.remal.lombok");
             build.applyPlugin("java");
@@ -52,8 +55,10 @@ class LombokPluginFunctionalTest {
             "",
             "import lombok.Data;",
             "",
+            "/** Test class */",
             "@Data",
             "public class TestClass {",
+            "    /** Test field */",
             "    private String field;",
             "}"
         ));

--- a/src/main/java/name/remal/gradle_plugins/lombok/AbstractLombokTask.java
+++ b/src/main/java/name/remal/gradle_plugins/lombok/AbstractLombokTask.java
@@ -1,6 +1,9 @@
 package name.remal.gradle_plugins.lombok;
 
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
+import static name.remal.gradle_plugins.lombok.JavacAllowUnsafeAccessUtils.getJavacAllowUnsafeAccessJvmArgs;
+import static name.remal.gradle_plugins.lombok.JavacAllowUnsafeAccessUtils.shouldSuppressUnsafeWarningJvmArgsBeAdded;
 import static name.remal.gradle_plugins.lombok.JavacPackagesToOpenUtils.getJavacPackageOpenJvmArgs;
 import static name.remal.gradle_plugins.lombok.JavacPackagesToOpenUtils.shouldJavacPackageOpenJvmArgsBeAdded;
 import static name.remal.gradle_plugins.toolkit.JavaLauncherUtils.getJavaLauncherProviderFor;
@@ -25,6 +28,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.jvm.toolchain.JavaLauncher;
 import org.gradle.process.ExecOperations;
 import org.gradle.process.JavaExecSpec;
+import org.jspecify.annotations.Nullable;
 
 @CacheableTask
 public abstract class AbstractLombokTask extends DefaultTask {
@@ -65,7 +69,7 @@ public abstract class AbstractLombokTask extends DefaultTask {
 
     @TaskAction
     public void execute() {
-        AtomicReference<JavaExecSpec> execSpecRef = new AtomicReference<>();
+        AtomicReference<@Nullable JavaExecSpec> execSpecRef = new AtomicReference<>();
 
         getExecOperations().javaexec(execSpec -> {
             var javaLauncher = getJavaLauncher().get();
@@ -74,6 +78,9 @@ public abstract class AbstractLombokTask extends DefaultTask {
                 .orElseGet(JavaVersion::current);
             if (shouldJavacPackageOpenJvmArgsBeAdded(javaVersion)) {
                 execSpec.jvmArgs(getJavacPackageOpenJvmArgs());
+            }
+            if (shouldSuppressUnsafeWarningJvmArgsBeAdded(javaVersion)) {
+                execSpec.jvmArgs(getJavacAllowUnsafeAccessJvmArgs());
             }
             execSpec.setExecutable(javaLauncher.getExecutablePath().getAsFile());
             execSpec.setClasspath(getToolClasspath());
@@ -85,7 +92,7 @@ public abstract class AbstractLombokTask extends DefaultTask {
             execSpecRef.set(execSpec);
         });
 
-        afterExecute(execSpecRef.get());
+        afterExecute(requireNonNull(execSpecRef.get()));
 
         setDidWork(true);
     }

--- a/src/main/java/name/remal/gradle_plugins/lombok/JavacAllowUnsafeAccessUtils.java
+++ b/src/main/java/name/remal/gradle_plugins/lombok/JavacAllowUnsafeAccessUtils.java
@@ -1,0 +1,47 @@
+package name.remal.gradle_plugins.lombok;
+
+import static java.lang.Integer.parseInt;
+import static lombok.AccessLevel.PRIVATE;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import lombok.NoArgsConstructor;
+import org.gradle.api.JavaVersion;
+import org.jspecify.annotations.Nullable;
+
+@NoArgsConstructor(access = PRIVATE)
+abstract class JavacAllowUnsafeAccessUtils {
+
+    private static final int FIRST_SUPPORTED_JAVA_VERSION = 23;
+
+    public static boolean shouldSuppressUnsafeWarningJvmArgsBeAdded(JavaVersion javaVersion) {
+        var majorVersion = parseInt(javaVersion.getMajorVersion());
+        return majorVersion >= FIRST_SUPPORTED_JAVA_VERSION;
+    }
+
+
+    private static final List<String> JAVAC_ALLOW_UNSAFE_ACCESS_JVM_ARGS = List.of(
+        "--sun-misc-unsafe-memory-access=allow"
+    );
+
+    public static List<String> getJavacAllowUnsafeAccessJvmArgs() {
+        return JAVAC_ALLOW_UNSAFE_ACCESS_JVM_ARGS;
+    }
+
+    public static List<String> withJavacAllowUnsafeAccess(@Nullable Collection<String> args) {
+        List<String> result = new ArrayList<>();
+        if (args != null) {
+            result.addAll(args);
+        }
+
+        for (var jvmArg : getJavacAllowUnsafeAccessJvmArgs()) {
+            if (!result.contains(jvmArg)) {
+                result.add(jvmArg);
+            }
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/name/remal/gradle_plugins/lombok/JavacPackagesToOpenUtils.java
+++ b/src/main/java/name/remal/gradle_plugins/lombok/JavacPackagesToOpenUtils.java
@@ -12,29 +12,29 @@ import org.gradle.api.JavaVersion;
 import org.jspecify.annotations.Nullable;
 
 @NoArgsConstructor(access = PRIVATE)
-public abstract class JavacPackagesToOpenUtils {
+abstract class JavacPackagesToOpenUtils {
+
+    public static boolean shouldJavacPackageOpenJvmArgsBeAdded(JavaVersion javaVersion) {
+        return javaVersion.isJava9Compatible();
+    }
+
 
     private static final List<String> JAVAC_PACKAGES_TO_OPEN = List.of(
-    /*
-    "jdk.compiler/com.sun.tools.javac.code",
-    "jdk.compiler/com.sun.tools.javac.comp",
-    "jdk.compiler/com.sun.tools.javac.file",
-    "jdk.compiler/com.sun.tools.javac.main",
-    "jdk.compiler/com.sun.tools.javac.model",
-    "jdk.compiler/com.sun.tools.javac.parser",
-    "jdk.compiler/com.sun.tools.javac.processing",
-    "jdk.compiler/com.sun.tools.javac.tree",
-    "jdk.compiler/com.sun.tools.javac.util"
-    */
+        "jdk.compiler/com.sun.tools.javac.code",
+        "jdk.compiler/com.sun.tools.javac.comp",
+        "jdk.compiler/com.sun.tools.javac.file",
+        "jdk.compiler/com.sun.tools.javac.jvm",
+        "jdk.compiler/com.sun.tools.javac.main",
+        "jdk.compiler/com.sun.tools.javac.model",
+        "jdk.compiler/com.sun.tools.javac.parser",
+        "jdk.compiler/com.sun.tools.javac.processing",
+        "jdk.compiler/com.sun.tools.javac.tree",
+        "jdk.compiler/com.sun.tools.javac.util"
     );
 
     private static final List<String> JAVAC_PACKAGE_OPEN_JVM_ARGS = JAVAC_PACKAGES_TO_OPEN.stream()
         .map(it -> format("--add-opens=%s=ALL-UNNAMED", it))
         .collect(toUnmodifiableList());
-
-    public static boolean shouldJavacPackageOpenJvmArgsBeAdded(JavaVersion javaVersion) {
-        return javaVersion.isJava9Compatible();
-    }
 
     public static List<String> getJavacPackageOpenJvmArgs() {
         return JAVAC_PACKAGE_OPEN_JVM_ARGS;

--- a/src/main/java/name/remal/gradle_plugins/lombok/LombokPlugin.java
+++ b/src/main/java/name/remal/gradle_plugins/lombok/LombokPlugin.java
@@ -8,6 +8,8 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static name.remal.gradle_plugins.lombok.AnnotationProcessorsLombokOrderUtils.withFixedAnnotationProcessorFilesOrder;
 import static name.remal.gradle_plugins.lombok.AnnotationProcessorsLombokOrderUtils.withFixedAnnotationProcessorsOrder;
+import static name.remal.gradle_plugins.lombok.JavacAllowUnsafeAccessUtils.shouldSuppressUnsafeWarningJvmArgsBeAdded;
+import static name.remal.gradle_plugins.lombok.JavacAllowUnsafeAccessUtils.withJavacAllowUnsafeAccess;
 import static name.remal.gradle_plugins.lombok.JavacPackagesToOpenUtils.shouldJavacPackageOpenJvmArgsBeAdded;
 import static name.remal.gradle_plugins.lombok.JavacPackagesToOpenUtils.withJavacPackageOpens;
 import static name.remal.gradle_plugins.lombok.LombokDependencies.getLombokDependency;
@@ -185,9 +187,13 @@ public abstract class LombokPlugin implements Plugin<Project> {
                 }
 
                 var compileOptions = task.getOptions();
-                List<String> compilerArgs = compileOptions.getCompilerArgs();
-                compilerArgs = withJavacPackageOpens(compilerArgs);
-                compileOptions.setCompilerArgs(compilerArgs);
+                compileOptions.setFork(true);
+                var jvmArgs = compileOptions.getForkOptions().getJvmArgs();
+                jvmArgs = withJavacPackageOpens(jvmArgs);
+                if (shouldSuppressUnsafeWarningJvmArgsBeAdded(compilerJavaVersion)) {
+                    jvmArgs = withJavacAllowUnsafeAccess(jvmArgs);
+                }
+                compileOptions.getForkOptions().setJvmArgs(jvmArgs);
             });
         });
     }


### PR DESCRIPTION
## Summary

Lombok's `Permit` class calls `sun.misc.Unsafe::objectFieldOffset`, which is terminally deprecated and emits a warning during compilation on Java 23+ ([projectlombok/lombok#3852](https://github.com/projectlombok/lombok/issues/3852)). The upstream maintainers have declined to address it. As a workaround, the plugin now passes `--sun-misc-unsafe-memory-access=allow` to the javac fork and to the delombok JVM when the target Java runtime is 23 or newer.

While wiring this in, the `--add-opens` flags for `jdk.compiler` internals are re-enabled and routed through `forkOptions.jvmArgs` instead of `compilerArgs`, where they actually take effect.